### PR TITLE
feat: add response wrapper + structured error responses

### DIFF
--- a/backend/src/main/java/com/thiru/investment_tracker/advice/ResponseWrapperAdvice.java
+++ b/backend/src/main/java/com/thiru/investment_tracker/advice/ResponseWrapperAdvice.java
@@ -1,0 +1,46 @@
+package com.thiru.investment_tracker.advice;
+
+import com.thiru.investment_tracker.dto.ApiResponse;
+import com.thiru.investment_tracker.util.collection.TJsonMapper;
+import org.jspecify.annotations.NonNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@Profile("!integration-test")
+@RestControllerAdvice
+public class ResponseWrapperAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(@NonNull MethodParameter returnType,
+                            Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+        if (body instanceof ApiResponse) {
+            return body;
+        }
+
+        if (body instanceof String) {
+            return TJsonMapper.writeValueAsString(new ApiResponse<>(body));
+        }
+
+        if (selectedContentType == null || !selectedContentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+            return body;
+        }
+
+        return new ApiResponse<>(body);
+    }
+}

--- a/backend/src/main/java/com/thiru/investment_tracker/dto/ApiResponse.java
+++ b/backend/src/main/java/com/thiru/investment_tracker/dto/ApiResponse.java
@@ -1,0 +1,12 @@
+package com.thiru.investment_tracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private T data;
+}

--- a/backend/src/main/java/com/thiru/investment_tracker/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/thiru/investment_tracker/dto/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.thiru.investment_tracker.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+    private String timestamp;
+    private int status;
+    private String error;
+    private String message;
+    private String path;
+}

--- a/backend/src/main/java/com/thiru/investment_tracker/exception/ControllerAdviser.java
+++ b/backend/src/main/java/com/thiru/investment_tracker/exception/ControllerAdviser.java
@@ -20,8 +20,8 @@ import java.time.Instant;
 @RestControllerAdvice
 public class ControllerAdviser {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidInputException(IllegalArgumentException ex, HttpServletRequest request) {
+    @ExceptionHandler({IllegalArgumentException.class, HttpMessageNotReadableException.class})
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception ex, HttpServletRequest request) {
         log(ex);
         return buildErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), request);
     }
@@ -33,32 +33,20 @@ public class ControllerAdviser {
         return buildErrorResponse(HttpStatus.BAD_REQUEST.value(), message, request);
     }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleException(AccessDeniedException ex, HttpServletRequest request) {
-        log(ex);
-        return buildErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), request);
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ErrorResponse> handleException(HttpMessageNotReadableException ex, HttpServletRequest request) {
-        log(ex);
-        return buildErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), request);
-    }
-
-    @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<ErrorResponse> handleException(BadCredentialsException ex, HttpServletRequest request) {
+    @ExceptionHandler({AccessDeniedException.class, BadCredentialsException.class})
+    public ResponseEntity<ErrorResponse> handleUnauthorized(Exception ex, HttpServletRequest request) {
         log(ex);
         return buildErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<ErrorResponse> handleException(NoResourceFoundException ex, HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleNotFound(Exception ex, HttpServletRequest request) {
         log(ex);
         return buildErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex, HttpServletRequest request) {
         log(ex);
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(), request);
     }

--- a/backend/src/main/java/com/thiru/investment_tracker/exception/ControllerAdviser.java
+++ b/backend/src/main/java/com/thiru/investment_tracker/exception/ControllerAdviser.java
@@ -1,53 +1,76 @@
 package com.thiru.investment_tracker.exception;
 
 
+import com.thiru.investment_tracker.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.time.Instant;
 
 @Log4j2
 @RestControllerAdvice
 public class ControllerAdviser {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleInvalidInputException(IllegalArgumentException ex) {
+    public ResponseEntity<ErrorResponse> handleInvalidInputException(IllegalArgumentException ex, HttpServletRequest request) {
         log(ex);
-        return ResponseEntity.badRequest().body(ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException ex, HttpServletRequest request) {
+        log(ex);
+        String message = "Required request parameter '" + ex.getParameterName() + "' is not present";
+        return buildErrorResponse(HttpStatus.BAD_REQUEST.value(), message, request);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<String> handleException(AccessDeniedException ex) {
+    public ResponseEntity<ErrorResponse> handleException(AccessDeniedException ex, HttpServletRequest request) {
         log(ex);
-        return ResponseEntity.status(401).body(ex.getMessage());
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<String> handleException(HttpMessageNotReadableException ex) {
+    public ResponseEntity<ErrorResponse> handleException(HttpMessageNotReadableException ex, HttpServletRequest request) {
         log(ex);
-        return ResponseEntity.status(400).body(ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<String> handleException(BadCredentialsException ex) {
+    public ResponseEntity<ErrorResponse> handleException(BadCredentialsException ex, HttpServletRequest request) {
         log(ex);
-        return ResponseEntity.status(401).body(ex.getMessage());
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED.value(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<String> handleException(NoResourceFoundException ex) {
+    public ResponseEntity<ErrorResponse> handleException(NoResourceFoundException ex, HttpServletRequest request) {
         log(ex);
-        return ResponseEntity.status(404).body(ex.getMessage());
+        return buildErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage(), request);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleException(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {
         log(ex);
-        return ResponseEntity.status(500).body(ex.getMessage());
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), ex.getMessage(), request);
+    }
+
+    private static ResponseEntity<ErrorResponse> buildErrorResponse(int status, String message, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setTimestamp(Instant.now().toString());
+        errorResponse.setStatus(status);
+        errorResponse.setError(HttpStatus.valueOf(status).getReasonPhrase());
+        errorResponse.setMessage(message);
+        errorResponse.setPath(request.getRequestURI());
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
     private static void log(Exception ex) {


### PR DESCRIPTION
- Wrap all API responses in ApiResponse<data> via ResponseWrapperAdvice
- Return structured ErrorResponse JSON from ControllerAdviser for all exceptions
- Disable wrapper in integration-test profile to keep existing tests green